### PR TITLE
feat: REINS検索コパイロットにβ版表記を追加

### DIFF
--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -28,7 +28,7 @@ export const newsData: NewsItem[] = [
     id: "1",
     date: "2026.2.5",
     category: "release",
-    title: "REINS検索をAIで効率化する新ツール「REINS検索コパイロット」をリリースしました",
+    title: "REINS検索をAIで効率化する新ツール「REINS検索コパイロット」をβ版としてリリースしました",
     link: {
       url: "/services/reins-search-copilot",
       isExternal: false,

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -292,7 +292,7 @@ export const servicesData: ServiceDetail[] = [
   },
   {
     id: "reins-search-copilot",
-    title: "REINS検索コパイロット",
+    title: "REINS検索コパイロット(β版)",
     description: {
       title:
         "自然文で入力するだけ。AIがREINS検索条件を自動生成し、ワンクリックで画面に適用。",


### PR DESCRIPTION
## Summary
- サービスタイトル「REINS検索コパイロット」に「(β版)」を追加
- ニュースタイトルの「リリースしました」を「β版としてリリースしました」に変更

## Test plan
- [ ] `npm run dev` でローカル確認し、サービス一覧・詳細ページのタイトルに「(β版)」が表示されること
- [ ] ニュース欄のタイトルが「β版としてリリース」となっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)