### PR TITLE
feat: Google Analytics 4のトラッキングタグを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "realable-hp",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.1.6",
         "biome": "^0.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1496,6 +1497,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
+      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8348,6 +8362,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deploy:all": "npm run deploy:hosting && npm run deploy:functions"
   },
   "dependencies": {
+    "@next/third-parties": "^16.1.6",
     "biome": "^0.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Noto_Sans_JP } from "next/font/google";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import "./globals.css";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
@@ -80,6 +81,7 @@ export default function RootLayout({
           <Footer />
         </FirebaseProvider>
       </body>
+      <GoogleAnalytics gaId="G-NWH76LWYTF" />
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- `@next/third-parties`パッケージを導入し、`GoogleAnalytics`コンポーネントでGA4タグ（測定ID: `G-NWH76LWYTF`）を全ページに埋め込み
- hakoma-appと同じアプローチを採用

## Test plan
- [ ] `npm run build` が成功すること
- [ ] デプロイ後、Google Analyticsのリアルタイムレポートでアクセスが計測されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)