### PR TITLE
fix: ビルド時にApp Check必須の環境変数を注入

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm ci && npm run build
+      - run: npm ci
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,7 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm ci && npm run build
+      - run: npm ci
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY }}
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# fix: CIビルド時にApp Check必須の環境変数を注入

## 概要

`sendContactEmail` Cloud Function が 401 `Invalid or missing App Check token` を返す問題を修正。

## 原因

`.github/workflows/firebase-hosting-{merge,pull-request}.yml` の `npm run build` ステップに `NEXT_PUBLIC_*` 環境変数が一切渡されておらず、Next.js の静的エクスポート時にバンドルへ `undefined` が焼き込まれていた。結果：

1. `src/lib/firebase.ts:40` で `Missing NEXT_PUBLIC_RECAPTCHA_SITE_KEY` のため App Check 初期化が `null`
2. `getAppCheckToken()` も `null`
3. `src/services/emailService.ts:41` で `X-Firebase-AppCheck` ヘッダーなしのまま fetch
4. Cloud Function 側で 401

原因->もともとlocalから環境変数ごとbuild/deployしていたが、CI/CDパイプラインに組み込んでいなかった。

## 変更内容

`npm ci && npm run build` を2ステップに分割し、`npm run build` の `env:` で App Check に必要な4変数を注入：

- `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` — reCAPTCHA v3 実行
- `NEXT_PUBLIC_FIREBASE_API_KEY` — Firebase API 認証
- `NEXT_PUBLIC_FIREBASE_PROJECT_ID` — プロジェクト識別
- `NEXT_PUBLIC_FIREBASE_APP_ID` — アプリ識別

Auth/Storage/FCM 系の `AUTH_DOMAIN` / `STORAGE_BUCKET` / `MESSAGING_SENDER_ID` は現状未使用のため含めない。

## マージ前にやること

GitHub リポジトリの **Settings → Secrets and variables → Actions** で以下4つを Secret として登録（ローカル `.env` の値をコピー）：

- [x] `NEXT_PUBLIC_RECAPTCHA_SITE_KEY`
- [x] `NEXT_PUBLIC_FIREBASE_API_KEY`
- [x] `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
- [x] `NEXT_PUBLIC_FIREBASE_APP_ID`

## 動作確認

- [x] PR プレビュー（pull-request workflow）がビルド成功する
- [x] プレビュー URL でお問い合わせフォーム送信が成功する
- [x] DevTools の Network でリクエストに `X-Firebase-AppCheck` ヘッダーが含まれている
- [x] DevTools コンソールに `Missing NEXT_PUBLIC_RECAPTCHA_SITE_KEY` が出ていない

<img width="1892" height="860" alt="スクリーンショット 2026-05-14 午後7 57 03" src="https://github.com/user-attachments/assets/02e13371-d00a-42b0-847c-7be8f8be2d91" />

